### PR TITLE
Buffer Overflow in Z_probe()

### DIFF
--- a/Marlin_main.cpp
+++ b/Marlin_main.cpp
@@ -981,9 +981,9 @@ float z_probe() {
   plan_set_position(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS],
 		    current_position[E_AXIS]);
 
-  for(int8_t i=0; i < NUM_AXIS; i++) {
-    saved_position[i] = float(st_get_position(i) / axis_steps_per_unit[i]);
-    }
+  saved_position[X_AXIS] = float((st_get_position(X_AXIS)) / axis_steps_per_unit[X_AXIS]);
+  saved_position[Y_AXIS] = float((st_get_position(Y_AXIS)) / axis_steps_per_unit[Y_AXIS]);
+  saved_position[Z_AXIS] = float((st_get_position(Z_AXIS)) / axis_steps_per_unit[Z_AXIS]);
 
   feedrate = homing_feedrate[Z_AXIS];
   destination[Z_AXIS] = mm+2;


### PR DESCRIPTION
The saved_position variable is an array with a length of 3. NUM_AXIS
typically include an extruder on top of the 3 axis.
This cannot end well… This bug doesn’t seem to affect everybody but I
was experiencing some nasty effect with my configuration (I am using a
Mac and a Arduino Mega) where after Z_probing the Y axis was shorten
and the head crashed on the bed. The fix is not pretty but follow the
previous block of code.
