### PR TITLE
Support the PanelOne controller

### DIFF
--- a/Configuration.h
+++ b/Configuration.h
@@ -408,6 +408,10 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 //#define ULTIMAKERCONTROLLER //as available from the ultimaker online store.
 //#define ULTIPANEL  //the ultipanel as on thingiverse
 
+//The Think3dPrint3d Panelone
+// http://reprap.org/wiki/PanelOne
+//#define PANELONE
+
 // The MaKr3d Makr-Panel with graphic controller and SD support
 // http://reprap.org/wiki/MaKr3d_MaKrPanel
 //#define MAKRPANEL
@@ -452,6 +456,11 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #endif
 
 #if defined(ULTIMAKERCONTROLLER) || defined(REPRAP_DISCOUNT_SMART_CONTROLLER) || defined(G3D_PANEL)
+ #define ULTIPANEL
+ #define NEWPANEL
+#endif
+
+#if defined (PANELONE)
  #define ULTIPANEL
  #define NEWPANEL
 #endif

--- a/pins.h
+++ b/pins.h
@@ -470,12 +470,24 @@
   #ifdef ULTRA_LCD
 
     #ifdef NEWPANEL
-      #define LCD_PINS_RS 16 
-      #define LCD_PINS_ENABLE 17
-      #define LCD_PINS_D4 23
-      #define LCD_PINS_D5 25 
-      #define LCD_PINS_D6 27
-      #define LCD_PINS_D7 29
+     #ifdef PANELONE
+       #define LCD_PINS_RS 40 //AUX2 PIN 6
+       #define LCD_PINS_ENABLE 42 //AUX2 PIN 8
+       #define LCD_PINS_D4 65 //AUX2 PIN 10
+       #define LCD_PINS_D5 66 //AUX2 PIN 9
+       #define LCD_PINS_D6 44 //AUX2 PIN 7
+       #define LCD_PINS_D7 64 //AUX2 PIN 5
+       #define BTN_EN1 63 //AUX2 PIN 4 
+       #define BTN_EN2 59 //AUX2 PIN 3
+       #define BTN_ENC 49 //AUX3 PIN 7
+     #else
+       #define LCD_PINS_RS 16 
+       #define LCD_PINS_ENABLE 17
+       #define LCD_PINS_D4 23
+       #define LCD_PINS_D5 25 
+       #define LCD_PINS_D6 27
+       #define LCD_PINS_D7 29
+     #endif    
 
       #ifdef REPRAP_DISCOUNT_SMART_CONTROLLER
         #define BEEPER 37
@@ -505,11 +517,17 @@
           #define SHIFT_OUT 40 // shift register
           #define SHIFT_CLK 44 // shift register
           #define SHIFT_LD 42 // shift register
+      #else
+        #ifdef PANELONE
+          #define BTN_EN1 59 //AUX2 PIN 3 
+          #define BTN_EN2 63 //AUX2 PIN 4
+          #define BTN_ENC 49 //AUX3 PIN 7
         #else
           #define BTN_EN1 37
           #define BTN_EN2 35
           #define BTN_ENC 31  //the click
-        #endif
+        #endif //PANELONE
+      #endif //REPRAPWORLD_KEYPAD
 
         #ifdef G3D_PANEL
           #define SDCARDDETECT 49


### PR DESCRIPTION
This is a simple Open Source LCD controller for RAMPS that is
distributed with the Think3dPrint3d Mini Kossel kits.

The firmware changes are tested on RAMPS (it only effects the RAMPS part of pins.h) both enabled and disabled.

More details on the PanelOne:

KiCAD source files are here:
https://github.com/T3P3/PanelOne

Info on the RepRap Wiki:
http://reprap.org/wiki/PanelOne

Blog post with more details:
http://blog.think3dprint3d.com/2014/08/panelone-lcd-screen-for-33v-and-5v.html

Case design tutorial in OpenSCAD
http://blog.think3dprint3d.com/2014/04/OpenSCAD-PanelOne-case-design.html
